### PR TITLE
Fix/lol/asset upload connection

### DIFF
--- a/lib/plugins/fileStorage/AwsS3Storage.js
+++ b/lib/plugins/fileStorage/AwsS3Storage.js
@@ -26,14 +26,17 @@ class AwsS3Storage {
    * Create a writeable stream to which we can write file data.
    *
    * @param {string} assetName - The name of the asset that needs to be written.
+   * @param {function} done - Callback.
    * @return {object} - The writeable stream to store the data.
    */
-
   createWriteStream(assetName, done) {
     var writeStream = through2();
     var request = this.s3.upload({Key: assetName, Body: writeStream});
     var self = this;
     request.send(function(error, data) {
+      // We must alert the write stream that we have finished or it will
+      // not close the connection to the client.
+      writeStream.emit('close');
       if (error) {
         self.logger.error(error);
       }


### PR DESCRIPTION
This fixes an issue in which the asset receiver did properly close connections when uploading files to S3.

### To Reproduce
To reproduce the issue, remove this commit and use the asset uploader to attempt to upload an asset when the AWS S3 uploader is set. You should see the file make it to S3 but the uploader never actually finishes because the asset receiver never sends the close command. You'll also note that the data is not stored in levelDB.

### To Test
 - Switch the asset receiver config to use AWS and supply it with valid credentials to an AWS bucket.
 - Upload a file via the asset uploader.
 - Ensure you get the `Upload successful.` message.
 - Ensure the file is properly uploaded to S3 and can be downloaded.