### PR TITLE
Fix current asset

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -288,6 +288,7 @@ Server.prototype.routes.receiveFileAsset = function(req, res, done) {
       token: token,
       time: Date.now(),
       fileName: assetName,
+      bucket,
     };
     self.database.createAsset(bucket, assetName, assetId, metadata, function(error) {
       if (error) {

--- a/lib/plugins/database/LevelDB.js
+++ b/lib/plugins/database/LevelDB.js
@@ -221,9 +221,9 @@ class LevelStore {
   }
 
   /**
-   * @return {object} - A JSON stream of existing assets.
+   * List all assets in the database.
    *
-   * TODO Can be removed after the migrating data to the new key format.
+   * @return {object} - A JSON stream of existing assets.
    */
   listAssets() {
     var stream = this.db.createReadStream({
@@ -241,6 +241,27 @@ class LevelStore {
     });
     stream.pipe(transform);
     return transform;
+  }
+
+  getPlaceholderText(character, number) {
+    var padding = '';
+    for (let i = 0; i < number; i++) {
+      padding += character;
+    }
+    return padding;
+  }
+
+  /**
+   * List all versions of a given asset.
+   *
+   * @param {string} assetId - The id of the asset.
+   * @return {Readable} - A readable JSON stream.
+   */
+  listAssetVersions(bucketId, assetName) {
+    return this.db.createReadStream({
+      gt: `bucket-asset-version!!${bucketId}!!${assetName}!!!`,
+      lt: `bucket-asset-version!!${bucketId}!!${assetName}!!~`,
+    });
   }
 
   /**

--- a/migrations/0003-fix-current-asset
+++ b/migrations/0003-fix-current-asset
@@ -1,0 +1,102 @@
+#! /usr/bin/env node
+'use strict';
+
+var Loader = require('yaml-config-loader');
+var yargs = require('yargs');
+var path = require('path');
+var bunyan = require('bunyan');
+var through2 = require('through2');
+
+var plugins = require('../lib/plugins');
+
+var loader = new Loader({stopOnError: false});
+var logger = bunyan.createLogger({name: 'probo-asset-fixer'});
+
+var cliargs = yargs
+  .describe('config', 'A path to a one or more configuration files or directories.')
+  .alias('config', 'c');
+
+var argv = cliargs.argv;
+
+if (argv.help) {
+  cliargs.showHelp();
+  throw new Error();
+}
+
+loader.on('error', function(error) {
+  // Ignore errors due to missing files.
+});
+
+loader.add(path.join(__dirname, '..', 'defaults.config.yaml'), {filterKeys: true});
+loader.addAndNormalizeObject(process.env);
+
+if (argv.config) {
+  if (typeof argv.config === 'string') {
+    argv.config = [argv.config];
+  }
+  argv.config.forEach(function(arg) {
+    loader.add(path.resolve(arg));
+  });
+}
+
+loader.addAndNormalizeObject(argv);
+
+var streamToArray = function(done) {
+  var foo = null;
+  var elements = [];
+  var transform = function(data, enc, cb) {
+    elements.push(data);
+    cb();
+  };
+  var flush = function(cb) {
+    done(null, elements);
+    cb();
+  };
+  return through2.obj(transform, flush);
+};
+
+loader.load(function(error, config) {
+  config = config || {};
+  config.databasePlugin = 'LevelDB';
+  config.database = new plugins.database[config.databasePlugin](config.databaseConfig, logger);
+
+  // Used to generate IDs for asset uploads.
+  var assetIds = [];
+  var db = config.database;
+  var dbStream = db.listAssets();
+
+  dbStream
+    .pipe(through2.obj(function(data, enc, cb) {
+      var assetId = data.assetId;
+      var token = data.metadata.token;
+      var fileName = data.metadata.fileName;
+      db.getBucketFromToken(token, function(err, bucketId) {
+        if (error) logger.error(err);
+        data.metadata.bucket = bucketId;
+        // Set the bucket Id on the asset.
+        db.listAssetVersions(bucketId, fileName)
+          .pipe(streamToArray(function(error, elements) {
+            elements.sort(dateSort);
+            db.getAssetId(bucketId, fileName, function(error, currentId) {
+              var correctId = elements.shift().key.substr(-16);
+              if (currentId !== correctId) {
+                var key = `bucket-asset!!${bucketId}!!${fileName}`;
+                logger.info(`Updating ${key} from asset ${currentId} to ${correctId}`);
+                db.db.put(key, correctId, cb);
+              }
+            });
+          }));
+      });
+    }));
+});
+
+function dateSort(a, b) {
+  if (a.value.time > b.value.time) {
+    return 1;
+  }
+  if (a.value.time < b.value.time) {
+    return -1;
+  }
+  // a must be equal to b
+  return 0;
+}


### PR DESCRIPTION
The [data migration](https://github.com/ProboCI/probo-asset-receiver/blob/master/migrations/0000-probo-leveldb-key-update) created to update the key space to fix listing bugs unfortunately set the current asset to the wrong value in many cases. This migration adds a new api method to list asset versions, sorts them by date, then sets the asset the most recent one.