### PR TITLE
Add endpoint which streams database backup.

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -79,6 +79,7 @@ Server.prototype.setup = function() {
   // Maintenance endpoints.
   app.post('/service/upload-status', auth, bodyParser.json(), this.routes.uploadStatus);
   app.get('/service/upload-status', auth, this.routes.getUploadStatus);
+  app.get('/service/export-data', auth, this.routes.getDataExport);
 
   // routes not requiring authorization token
   app.post('/asset/:token/:assetName', this.routes.receiveFileAsset);
@@ -168,6 +169,13 @@ Server.prototype.routes.getUploadStatus = function(req, res, done) {
   return res
     .status(200)
     .send(`Uploads are ${pausedStatus}.`);
+};
+
+Server.prototype.routes.getDataExport = function(req, res, done) {
+  var readStream = this.database.exportData();
+  res.writeHead(200);
+  readStream
+    .pipe(res);
 };
 
 Server.prototype.routes.listBuckets = function(req, res, done) {

--- a/lib/plugins/database/LevelDB.js
+++ b/lib/plugins/database/LevelDB.js
@@ -209,8 +209,8 @@ class LevelStore {
   }
 
   /**
-  * @return {object} - A JSON stream of existing buckets.
-  */
+   * @return {object} - A JSON stream of existing buckets.
+   */
   listBuckets() {
     var stream = this.db.createReadStream({
       gt: 'bucket!!!',
@@ -229,6 +229,34 @@ class LevelStore {
     return transform;
   }
 
+  /**
+   * Used for database backups. Exports all data.
+   * @return {function} - Transformed data stream.
+   */
+  exportData() {
+    // We use values of two different types in the LevelDB data. Some are plain
+    // text while others are json. If we want to normalize this so that when we
+    // import it again it looks the same, we need to ensure that the JSON is
+    // identical. To do this cleanly, attempt to JSON parse each value and
+    // treat it as a string only if it cannot be parsed.
+    var stream = this.db.createReadStream({keyEncoding: 'text', valueEncoding: 'text'});
+    var transform = through2.obj(function(data, enc, cb) {
+      var val;
+      try {
+        val = JSON.parse(data.value);
+      }
+      catch (error) {
+        val = data.value;
+      }
+      var obj = {
+        key: data.key,
+        value: val,
+      };
+      cb(null, JSON.stringify(obj) + '\n');
+    });
+    stream.pipe(transform);
+    return transform;
+  }
 
   listBucketKeys() {
     var stream = this.db.createReadStream({

--- a/test/upload-test.js
+++ b/test/upload-test.js
@@ -447,5 +447,26 @@ describe('http-api', function() {
         done();
       });
     });
+    it('should stream the database over HTTP.', function(done) {
+      var options = getOptions('/service/export-data');
+      request(options, function(error, response, body) {
+        var objects = body.split('\n').filter(function(s) {
+          return s !== '';
+        })
+        .map(function(s) {
+          return JSON.parse(s);
+        });
+        objects.length.should.equal(4);
+        objects[0].key.should.equal('bucket!!bar');
+        objects[1].key.should.equal('bucket!!foo');
+        objects[1].value.bar.should.equal('baz');
+        objects[2].key.should.equal('bucket-token!!foo!!baz');
+        objects[2].value.should.be.a.Number();
+        objects[2].value.should.be.above(1400000000000);
+        objects[3].key.should.equal('token!!baz');
+        objects[3].value.should.equal('foo');
+        done();
+      });
+    });
   });
 });

--- a/test/upload-test.js
+++ b/test/upload-test.js
@@ -414,7 +414,6 @@ describe('http-api', function() {
     it('should give an appropriate message if uploads are not paused.', function(done) {
       var options = getOptions('/service/upload-status');
       request(options, function(error, response, body) {
-        console.log(body);
         body.should.equal('Uploads are unpaused.');
         done();
       });
@@ -423,12 +422,11 @@ describe('http-api', function() {
       var options = getOptions('/service/upload-status');
       server.uploadsPaused = true;
       request(options, function(error, response, body) {
-        console.log(body);
         body.should.equal('Uploads are paused.');
         done();
       });
     });
-    it('should pause the server upload status via post .', function(done) {
+    it('should pause the server upload status via post.', function(done) {
       var options = getOptions('/service/upload-status');
       options.body = {
         uploadsPaused: true,
@@ -438,7 +436,7 @@ describe('http-api', function() {
         done();
       });
     });
-    it('should unpause the server upload status via post .', function(done) {
+    it('should unpause the server upload status via post.', function(done) {
       server.uploadsPaused = true;
       var options = getOptions('/service/upload-status');
       options.body = {


### PR DESCRIPTION
We want to be able to backup our levelDb database to a file. To
handle this we create an endpoint (to be used by Jenkins) which
streams the data from levelDb as line delimited JSON.

### To test
 - Start the server and then
 - `curl -H "Authorization: Bearer assetsDevToken" http://localhost:3070/service/export-data`
 - Ensure that the lines parse as valid JSON.